### PR TITLE
Add chat title search

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ python main.py messages @channel_name
 python main.py messages https://t.me/channel_name
 ```
 
+Для приватных чатов используйте название чата:
+
+```bash
+python main.py messages "Название чата"
+```
+
 Дополнительные параметры:
 - Указание количества сообщений:
 ```bash
@@ -71,6 +77,12 @@ python main.py messages @channel_name -l 20
 
 ```bash
 python main.py stats @channel_name
+```
+
+Для приватных чатов можно указать название чата:
+
+```bash
+python main.py stats "Название чата"
 ```
 
 Дополнительные параметры:
@@ -91,6 +103,12 @@ python main.py stats @channel_name -t
 
 ```bash
 python main.py export @channel_name -o messages.csv
+```
+
+Для приватных чатов укажите название чата:
+
+```bash
+python main.py export "Название чата" -o messages.csv
 ```
 
 В режиме отладки можно экспортировать только первые 100 сообщений:


### PR DESCRIPTION
## Summary
- add `find_chat_by_title` helper to look through dialogs
- use helper in `get_messages`, `get_channel_stats`, and `export_channel_csv`
- document passing a private chat title in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846b975ce98832c9a5f82aeefbc2cc1